### PR TITLE
Code Review: Convert hello-world plugin example to use API (#9534)

### DIFF
--- a/Hello World.sketchplugin/Contents/Sketch/hello-world.js
+++ b/Hello World.sketchplugin/Contents/Sketch/hello-world.js
@@ -56,34 +56,23 @@
 function onRun(context) {
 
   // We are passed a context variable when we're run.
-  // This is a dictionary containing a reference to the document,
-  // the current selection, the plugin, current URL and more.
+  // We use this to get hold of a javascript object
+  // which we can use in turn to manipulate Sketch.
+  var sketch = context.api()
 
-  // One of the things that the context contains is the current document,
-  // so let's fetch that.
-  var doc = context.document;
+  // Next we want to extract the selected page of the selected (front-most) document
+  var document = sketch.selectedDocument
+  var page = document.selectedPage
 
-  // From the document, we can fetch the current page that the user is looking at.
-  var page = [doc currentPage];
-
-  // Now let's create a new text layer...
-
-  var layer = MSTextLayer.alloc().initWithFrame_(NSMakeRect(0, 0, 100, 100))
-  // ...give it a large font...
-  layer.font = NSFont.systemFontOfSize_(36.0)
-
-  // ...set its text to a traditional value...
-  layer.stringValue = "Hello World!"
+  // Now let's create a new text layer, using a large font, and a traditional value...
+  var layer = page.newText({alignment: NSTextAlignmentCenter, systemFontSize: 36, text:"Hello World"})
 
   // ...resize it so that the text just fits...
-  layer.adjustFrameToFit()
-
-  // ...and add it to the page
-  page.addLayers_([layer])
+  layer.resizeToFitContents()
 
   // Finally, lets center the view on our new layer
   // so that we can see where it is.
-  doc.currentView().centerRect_(layer.rect())
+  document.centerOnLayer(layer)
 };
 
 // And that's it. Job done.

--- a/Hello World.sketchplugin/Contents/Sketch/manifest.json
+++ b/Hello World.sketchplugin/Contents/Sketch/manifest.json
@@ -1,7 +1,7 @@
 {
     "name" : "Hello World!",
     "identifier" : "com.sketchapp.examples.helloworld",
-    "version" : "1.0.1",
+    "version" : "1.0.2",
     "description" : "Pretty much the smallest example Sketch Plugin you could have.",
     "authorEmail" : "sam@sketchapp.com",
     "author" : "Sam Deane",


### PR DESCRIPTION
Code review for Convert hello-world plugin example to use API (#9534):

> Wherever possible, our plugins should use the JS API, so that when people copy them, they also use the API.


Connect to BohemianCoding/Sketch#9534.